### PR TITLE
add herumi bls library to dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/graph-gophers/graphql-go v1.3.0
 	github.com/hashicorp/go-bexpr v0.1.10
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d
+	github.com/herumi/bls-eth-go-binary v0.0.0-20220216073600-600054663ec1 // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3
 	github.com/holiman/uint256 v1.2.0
 	github.com/huin/goupnp v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d h1:dg1dEPuWpEqDnvIw251EVy4zlP8gWbsGj4BsUKCRpYs=
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/herumi/bls-eth-go-binary v0.0.0-20220216073600-600054663ec1 h1:grF9w60kNiJxs2Vk97UsM+Sr/Qb1EfOop6Uh3aKDldg=
+github.com/herumi/bls-eth-go-binary v0.0.0-20220216073600-600054663ec1/go.mod h1:luAnRm3OsMQeokhGzpYmc0ZKwawY7o87PUEP11Z7r7U=
 github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=
 github.com/holiman/bloomfilter/v2 v2.0.3/go.mod h1:zpoh+gs7qcpqrHr3dB55AMiJwo0iURXE7ZOP9L9hSkA=
 github.com/holiman/uint256 v1.2.0 h1:gpSYcPLWGv4sG43I2mVLiDZCNDh/EpGjSk8tmtxitHM=


### PR DESCRIPTION
The current version seems to miss the Herumi BLS library dependency in the `go.mod`, resulting in the following error when building:

```
env GO111MODULE=on go run build/ci.go install ./cmd/geth
>>> /snap/go/9028/bin/go build -ldflags -X main.gitCommit=b67b6ff2d668e9ba728a3d2a14887fbdb0267a55 -X main.gitDate=20220220 -extldflags -Wl,-z,stack-size=0x800000 -trimpath -v -o /home/martin/disco/testbed/go-ethereum/build/bin/geth ./cmd/geth
core/vm/contracts.go:38:2: no required module provides package github.com/herumi/bls-eth-go-binary/bls; to add it:
	go get github.com/herumi/bls-eth-go-binary/bls
util.go:46: exit status 1
exit status 1
make: *** [Makefile:12: geth] Error 1
```

This PR merely adds the dependency to the `go.mod` file.